### PR TITLE
Bump to Vivado 2023.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ access to the 2 x 2 GiB of on-board DDR 4 memory.
 This design is heavily inspired by the FPGA Development Kit provided for Amazon
 F1 instances, but simplified and adapted for the VCU118.
 
-Building and modifying the shell requires Vivado 2019.1.
+Building and modifying the shell requires Vivado 2023.1.
 
 ## Basic structure
 

--- a/ip/tcl/build.tcl
+++ b/ip/tcl/build.tcl
@@ -30,7 +30,7 @@ if {[llength $argv] != 1} {
 set ip_module_name [lindex $argv 0]
 
 create_project -in_memory -part xcvu9p-flga2104-2L-e
-set_property board_part xilinx.com:vcu118:part0:2.3 [current_project]
+set_property board_part xilinx.com:vcu118:part0:2.4 [current_project]
 
 source "$source_dir/tcl/$ip_module_name.tcl"
 

--- a/shell/tcl/empty/project.tcl
+++ b/shell/tcl/empty/project.tcl
@@ -25,7 +25,7 @@ set garnet_dir "$garnet_shell_dir/.."
 set project_name "project"
 
 create_project -force empty -part xcvu9p-flga2104-2L-e
-set_property board_part xilinx.com:vcu118:part0:2.3 [current_project]
+set_property board_part xilinx.com:vcu118:part0:2.4 [current_project]
 
 source "$garnet_dir/tcl/waivers_ip.tcl"
 source "$garnet_dir/tcl/waivers_shell.tcl"

--- a/shell/tcl/shell.tcl
+++ b/shell/tcl/shell.tcl
@@ -51,7 +51,7 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
    create_project project_1 myproj -part xcvu9p-flga2104-2L-e
-   set_property BOARD_PART xilinx.com:vcu118:part0:2.3 [current_project]
+   set_property BOARD_PART xilinx.com:vcu118:part0:2.4 [current_project]
 }
 
 

--- a/shell/tcl/shell.tcl
+++ b/shell/tcl/shell.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2019.1
+set scripts_vivado_version 2023.1
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -131,13 +131,13 @@ set bCheckIPsPassed 1
 set bCheckIPs 1
 if { $bCheckIPs == 1 } {
    set list_check_ips "\ 
-xilinx.com:ip:axi_firewall:1.0\
+xilinx.com:ip:axi_firewall:1.2\
 xilinx.com:ip:debug_bridge:3.0\
-xilinx.com:ip:util_ds_buf:2.1\
+xilinx.com:ip:util_ds_buf:2.2\
 xilinx.com:ip:util_vector_logic:2.0\
 xilinx.com:ip:xdma:4.1\
 xilinx.com:ip:axi_register_slice:2.1\
-xilinx.com:ip:pr_decoupler:1.0\
+xilinx.com:ip:dfx_decoupler:1.0\
 xilinx.com:ip:proc_sys_reset:5.0\
 "
 
@@ -337,7 +337,7 @@ proc create_hier_cell_shim { parentCell nameHier } {
  ] [get_bd_pins /shim/irq_shim/clk]
 
   # Create instance: pr_decoupler_CTL, and set properties
-  set pr_decoupler_CTL [ create_bd_cell -type ip -vlnv xilinx.com:ip:pr_decoupler:1.0 pr_decoupler_CTL ]
+  set pr_decoupler_CTL [ create_bd_cell -type ip -vlnv xilinx.com:ip:dfx_decoupler:1.0 pr_decoupler_CTL ]
   set_property -dict [ list \
    CONFIG.ALL_PARAMS {INTF {CTL_AXI_LITE {ID 0 VLNV xilinx.com:interface:aximm_rtl:1.0 MODE slave PROTOCOL axi4lite SIGNALS {ARVALID {PRESENT 1 WIDTH 1} ARREADY {PRESENT 1 WIDTH 1} AWVALID {PRESENT 1 WIDTH 1} AWREADY {PRESENT 1 WIDTH 1} BVALID {PRESENT 1 WIDTH 1} BREADY {PRESENT 1 WIDTH 1} RVALID {PRESENT 1 WIDTH 1} RREADY {PRESENT 1 WIDTH 1} WVALID {PRESENT 1 WIDTH 1} WREADY {PRESENT 1 WIDTH 1} AWADDR {PRESENT 1 WIDTH 32} AWLEN {PRESENT 0 WIDTH 8} AWSIZE {PRESENT 0 WIDTH 3} AWBURST {PRESENT 0 WIDTH 2} AWLOCK {PRESENT 0 WIDTH 1} AWCACHE {PRESENT 0 WIDTH 4} AWPROT {PRESENT 1 WIDTH 3} WDATA {PRESENT 1 WIDTH 32} WSTRB {PRESENT 1 WIDTH 4} WLAST {PRESENT 0 WIDTH 1} BRESP {PRESENT 1 WIDTH 2} ARADDR {PRESENT 1 WIDTH 32} ARLEN {PRESENT 0 WIDTH 8} ARSIZE {PRESENT 0 WIDTH 3} ARBURST {PRESENT 0 WIDTH 2} ARLOCK {PRESENT 0 WIDTH 1} ARCACHE {PRESENT 0 WIDTH 4} ARPROT {PRESENT 1 WIDTH 3} RDATA {PRESENT 1 WIDTH 32} RRESP {PRESENT 1 WIDTH 2} RLAST {PRESENT 0 WIDTH 1} AWID {PRESENT 0 WIDTH 0} AWREGION {PRESENT 1 WIDTH 4} AWQOS {PRESENT 1 WIDTH 4} AWUSER {PRESENT 0 WIDTH 0} WID {PRESENT 0 WIDTH 0} WUSER {PRESENT 0 WIDTH 0} BID {PRESENT 0 WIDTH 0} BUSER {PRESENT 0 WIDTH 0} ARID {PRESENT 0 WIDTH 0} ARREGION {PRESENT 1 WIDTH 4} ARQOS {PRESENT 1 WIDTH 4} ARUSER {PRESENT 0 WIDTH 0} RID {PRESENT 0 WIDTH 0} RUSER {PRESENT 0 WIDTH 0}}}} HAS_SIGNAL_STATUS 1 IPI_PROP_COUNT 4} \
    CONFIG.GUI_HAS_SIGNAL_STATUS {1} \
@@ -379,7 +379,7 @@ proc create_hier_cell_shim { parentCell nameHier } {
  ] $pr_decoupler_CTL
 
   # Create instance: pr_decoupler_DMA, and set properties
-  set pr_decoupler_DMA [ create_bd_cell -type ip -vlnv xilinx.com:ip:pr_decoupler:1.0 pr_decoupler_DMA ]
+  set pr_decoupler_DMA [ create_bd_cell -type ip -vlnv xilinx.com:ip:dfx_decoupler:1.0 pr_decoupler_DMA ]
   set_property -dict [ list \
    CONFIG.ALL_PARAMS {INTF {DMA_AXI {ID 0 VLNV xilinx.com:interface:aximm_rtl:1.0 MODE slave SIGNALS {ARVALID {PRESENT 1 WIDTH 1} ARREADY {PRESENT 1 WIDTH 1} AWVALID {PRESENT 1 WIDTH 1} AWREADY {PRESENT 1 WIDTH 1} BVALID {PRESENT 1 WIDTH 1} BREADY {PRESENT 1 WIDTH 1} RVALID {PRESENT 1 WIDTH 1} RREADY {PRESENT 1 WIDTH 1} WVALID {PRESENT 1 WIDTH 1} WREADY {PRESENT 1 WIDTH 1} AWID {PRESENT 1 WIDTH 4} AWADDR {PRESENT 1 WIDTH 64} AWLEN {PRESENT 1 WIDTH 8} AWSIZE {PRESENT 1 WIDTH 3} AWBURST {PRESENT 1 WIDTH 2} AWLOCK {PRESENT 1 WIDTH 1} AWCACHE {PRESENT 1 WIDTH 4} AWPROT {PRESENT 1 WIDTH 3} AWREGION {PRESENT 1 WIDTH 4} AWQOS {PRESENT 1 WIDTH 4} AWUSER {PRESENT 0 WIDTH 0} WID {PRESENT 1 WIDTH 4} WDATA {PRESENT 1 WIDTH 512} WSTRB {PRESENT 1 WIDTH 64} WLAST {PRESENT 1 WIDTH 1} WUSER {PRESENT 0 WIDTH 0} BID {PRESENT 1 WIDTH 4} BRESP {PRESENT 1 WIDTH 2} BUSER {PRESENT 0 WIDTH 0} ARID {PRESENT 1 WIDTH 4} ARADDR {PRESENT 1 WIDTH 64} ARLEN {PRESENT 1 WIDTH 8} ARSIZE {PRESENT 1 WIDTH 3} ARBURST {PRESENT 1 WIDTH 2} ARLOCK {PRESENT 1 WIDTH 1} ARCACHE {PRESENT 1 WIDTH 4} ARPROT {PRESENT 1 WIDTH 3} ARREGION {PRESENT 1 WIDTH 4} ARQOS {PRESENT 1 WIDTH 4} ARUSER {PRESENT 0 WIDTH 0} RID {PRESENT 1 WIDTH 4} RDATA {PRESENT 1 WIDTH 512} RRESP {PRESENT 1 WIDTH 2} RLAST {PRESENT 1 WIDTH 1} RUSER {PRESENT 0 WIDTH 0}}}} HAS_SIGNAL_STATUS 1 IPI_PROP_COUNT 4} \
    CONFIG.GUI_HAS_SIGNAL_STATUS {1} \
@@ -506,10 +506,10 @@ proc create_hier_cell_PCI_DMA { parentCell nameHier } {
   create_bd_pin -dir I -type rst pcie_perstn
 
   # Create instance: axi_firewall_CTL, and set properties
-  set axi_firewall_CTL [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_firewall:1.0 axi_firewall_CTL ]
+  set axi_firewall_CTL [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_firewall:1.2 axi_firewall_CTL ]
 
   # Create instance: axi_firewall_DMA, and set properties
-  set axi_firewall_DMA [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_firewall:1.0 axi_firewall_DMA ]
+  set axi_firewall_DMA [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_firewall:1.2 axi_firewall_DMA ]
 
   # Create instance: axi_firewall_auto_un_CTL, and set properties
   set block_name axi_firewall_auto_unblocker
@@ -568,7 +568,7 @@ proc create_hier_cell_PCI_DMA { parentCell nameHier } {
  ] [get_bd_pins /PCI_DMA/decouple_pipeline/clk]
 
   # Create instance: util_ds_buf_pcie_refclk, and set properties
-  set util_ds_buf_pcie_refclk [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.1 util_ds_buf_pcie_refclk ]
+  set util_ds_buf_pcie_refclk [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.2 util_ds_buf_pcie_refclk ]
   set_property -dict [ list \
    CONFIG.C_BUF_TYPE {IBUFDSGTE} \
    CONFIG.DIFF_CLK_IN_BOARD_INTERFACE {pcie_refclk} \
@@ -606,7 +606,7 @@ proc create_hier_cell_PCI_DMA { parentCell nameHier } {
    CONFIG.ext_xvc_vsec_enable {false} \
    CONFIG.gtcom_in_core_usp {2} \
    CONFIG.gtwiz_in_core_usp {1} \
-   CONFIG.mcap_enablement {PR_over_PCIe} \
+   CONFIG.mcap_enablement {DFX_over_PCIe} \
    CONFIG.mcap_fpga_bitstream_version {00000001} \
    CONFIG.mode_selection {Advanced} \
    CONFIG.pcie_blk_locn {X1Y2} \

--- a/tcl/build.tcl
+++ b/tcl/build.tcl
@@ -52,7 +52,7 @@ proc garnet_create_synth_project {args} {
   global disable_debug_bridge
 
   create_project -in_memory -part xcvu9p-flga2104-2L-e {*}$args
-  set_property board_part xilinx.com:vcu118:part0:2.3 [current_project]
+  set_property board_part xilinx.com:vcu118:part0:2.4 [current_project]
 
   set config_fd [open garnet_config.vh w]
   puts $config_fd "`ifndef GARNET_CONFIG_SVH"
@@ -117,7 +117,7 @@ proc garnet_create_impl_project {args} {
   global garnet_dir
 
   create_project -in_memory -part xcvu9p-flga2104-2L-e {*}$args
-  set_property board_part xilinx.com:vcu118:part0:2.3 [current_project]
+  set_property board_part xilinx.com:vcu118:part0:2.4 [current_project]
 
   source "$garnet_dir/tcl/waivers_ip.tcl"
   source "$garnet_dir/tcl/waivers_shell.tcl"


### PR DESCRIPTION
Vivado 2019.1 is pretty old for now. Moreover, Vivado 2021 and higher will be faster in implementation. However, this repo can only run on Vivado 2019.1 currently.

I did some bump work in this PR by modifying the IP version in the Tcl script and changing the property values to adopt the newer version. (i.e. replace "pr" with "dfx")

I also tested it on firesim and checked the logs from Vivado, everything worked well. I can get Linux running on Rocket-Chip on VCU118.